### PR TITLE
fix: the key not disappear when note on at velocity 0.

### DIFF
--- a/Arduino-IDE-Sketch/M5Stack_SMF_Player/SmfSeq.cpp
+++ b/Arduino-IDE-Sketch/M5Stack_SMF_Player/SmfSeq.cpp
@@ -724,7 +724,6 @@ int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
           }
           MidiData1 = (int)MidiData[0];
           MidiData2 = (int)MidiData[1];
-          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, MidiData2);
           //ノートオンによるノートオフ対策
           if (MidiData2 == 0)
           {
@@ -740,6 +739,7 @@ int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
             Ret = SMF_NG;
             break;
           }
+          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, MidiData2);
           Ret = SMF_OK;
           break;
         case MIDI_STATCH_PKEYPRES:


### PR DESCRIPTION
ベロシティ0のノートオンはノートオフとして扱いキー表示が消えるようにしました。