### PR TITLE
Add: a pragma gcc option and lcd.startWrite()/lcd.endWrite()

### DIFF
--- a/Arduino-IDE-Sketch/M5Stack_SMF_Player/M5Stack_SMF_Player.ino
+++ b/Arduino-IDE-Sketch/M5Stack_SMF_Player/M5Stack_SMF_Player.ino
@@ -281,14 +281,14 @@ void backscreen()
   {
     int y = 49 + chd * 10;
     lcd.drawNumber(chd, 4, y + 1);
-    lcd.drawFastHLine(2, 58 + chd * 10, 316, 0xF660);
-
+    lcd.drawFastHLine(2, y-1, 316, 0xF660);
+    lcd.fillRect(18, y, 300, 9, TFT_DARKGREY);
+    lcd.setColor(TFT_BLACK);
     for (int oct = 0; oct < 11; ++oct) {
       int x = 18 + oct * 28;
       for (int n = 0; n < 7; ++n) {
-        lcd.fillRect(x + n * 4, y, 3, 9, TFT_DARKGREY);
+        lcd.drawFastVLine(x + n * 4 + 3, y, 9);
       }
-      lcd.setColor(TFT_BLACK);
       lcd.fillRect(x +  2, y, 3, 5);
       lcd.fillRect(x +  6, y, 3, 5);
       lcd.fillRect(x + 14, y, 3, 5);
@@ -298,7 +298,6 @@ void backscreen()
   }
   lcd.drawFastVLine( 16, 58, 161, 0xF660);
   lcd.drawRect( 1, 58, 318, 161, 0xF660);
-  lcd.drawFastVLine( 319, 58, 161, 0);
 }
 
 void setup()

--- a/Arduino-IDE-Sketch/M5Stack_SMF_Player/M5Stack_SMF_Player.ino
+++ b/Arduino-IDE-Sketch/M5Stack_SMF_Player/M5Stack_SMF_Player.ino
@@ -310,18 +310,12 @@ void setup()
   // 最初に初期化関数を呼び出します。
   lcd.init();
 
-  // 回転方向を 0～3 の4方向から設定します。(4～7を使用すると上下反転になります。)
   lcd.setRotation(1);
 
   // バックライトの輝度を 0～255 の範囲で設定します。
-  lcd.setBrightness(255); // の範囲で設定
-                          // M5Stick-Cのバックライト調整は現在非対応です。
-                          // AXP192ライブラリを別途includeして設定してください。
+  lcd.setBrightness(255);
 
-
-  // clearまたはfillScreenで画面全体を塗り潰します。
-  // どちらも同じ動作をしますが、clearは引数を省略でき、その場合は黒で塗り潰します。
-  lcd.clear(0x0000); // 黒で塗り潰し
+  lcd.clear(TFT_BLACK);
 
   Serial.begin(115200);
 
@@ -405,7 +399,7 @@ void loop()
         SmfSeqPlayResetTrkTbl(pseqTbl);
         // ファイルクローズ
         SmfSeqEnd(pseqTbl);
-        lcd.fillRect(280, 5, 310, 45, BLACK);
+        lcd.fillRect(280, 5, 310, 45, TFT_BLACK);
         lcd.setFont(&fonts::Font4);
         lcd.setCursor(5, 27);
         lcd.setTextSize(1);

--- a/Arduino-IDE-Sketch/M5Stack_SMF_Player/SmfSeq.cpp
+++ b/Arduino-IDE-Sketch/M5Stack_SMF_Player/SmfSeq.cpp
@@ -10,6 +10,8 @@
 #include "MidiFunc.h"      //MIDIインタフェース
 #include "SmfSeq.h"
 
+#pragma GCC optimize ("O3")
+
 //-----------------------------------------------------------------------------
 //SMFシーケンス用テーブル
 //-----------------------------------------------------------------------------
@@ -539,10 +541,10 @@ inline void drawKey(int note, int ch, bool press)
   int oct = note / 12;
   int idx = note - oct * 12;
   int dx = 18 + oct * 28 + note_x[idx];
-  int dy = 60 +  ch * 10 + note_y[idx];
+  int dy = 61 +  ch * 10 + note_y[idx];
   int color = TFT_WHITE;
   if (!press) color = note_y[idx] ? TFT_DARKGREY : TFT_BLACK;
-  lcd.fillRect(dx, dy, 3, 3, color);
+  lcd.fillRect(dx, dy, 3, 2, color);
 }
 
 int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
@@ -701,17 +703,18 @@ int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
           }
           MidiData1 = (int)MidiData[0];
           MidiData2 = (int)MidiData[1];
-
+          lcd.startWrite();
+          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, false);
           Ret = midiOutShortMsg((UCHAR)MidiStatus,
                                 (UCHAR)MidiData1,
                                 (UCHAR)MidiData2);
+          lcd.endWrite();
           if (Ret == MIDI_NG)
           {
             ptrkTbl->TrackStatus = SMF_TRKSTAT_TRACKEND;
             Ret = SMF_NG;
             break;
           }
-          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, false);
           Ret = SMF_OK;
           break;
         case MIDI_STATCH_NOTEON:
@@ -724,6 +727,8 @@ int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
           }
           MidiData1 = (int)MidiData[0];
           MidiData2 = (int)MidiData[1];
+          lcd.startWrite();
+          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, MidiData2);
           //ノートオンによるノートオフ対策
           if (MidiData2 == 0)
           {
@@ -733,13 +738,13 @@ int SmfSeqEventProc(SMF_SEQ_TABLE *pseqTbl, SMF_TRACK_TABLE *ptrkTbl)
           Ret = midiOutShortMsg((UCHAR)MidiStatus,
                                 (UCHAR)MidiData1,
                                 (UCHAR)MidiData2);
+          lcd.endWrite();
           if (Ret == MIDI_NG)
           {
             ptrkTbl->TrackStatus = SMF_TRKSTAT_TRACKEND;
             Ret = SMF_NG;
             break;
           }
-          drawKey(MidiData1, MidiStatus & MIDI_CHANNEL_MASK, MidiData2);
           Ret = SMF_OK;
           break;
         case MIDI_STATCH_PKEYPRES:


### PR DESCRIPTION
・処理時間を短縮するため コンパイラの最適化オプション O3 を指定しました。
・ノート描画面積を9pixelから6pixelに減らしました。
・ノート描画処理の待ち時間を短縮するため、MIDI送信前にSPI確保と描画を行い、MIDI送信後にSPI解放するようタイミングを変更しました。